### PR TITLE
Use correct user logged in flag

### DIFF
--- a/01-Login/views/index.pug
+++ b/01-Login/views/index.pug
@@ -2,7 +2,7 @@ extends layout
 
 block content
   .w3-container
-    if loggedIn
+    if locals.user
       h4 You are logged in!
     else
       h4 You are not logged in! Please #[a(href="/login") Log In] to continue.


### PR DESCRIPTION
This view seems to be using the older `userLoggedIn` flag. This change switches it over to the new `locals.user` expression which evaluates truthy if there is a logged in user.