### PR TITLE
Fix ReferenceError

### DIFF
--- a/01-Login/routes/auth.js
+++ b/01-Login/routes/auth.js
@@ -38,6 +38,9 @@ router.get('/logout', (req, res) => {
   if (port !== undefined && port !== 80 && port !== 443) {
     returnTo += ':' + port;
   }
+  if (URL === undefined) {
+    var URL = url.URL;
+  }
   var logoutURL = new URL(
     util.format('https://%s/logout', process.env.AUTH0_DOMAIN)
   );


### PR DESCRIPTION
When I run "01-Login" sample with Docker, the "Log Out" link shows "ReferenceError: URL is not defined".

In Node.js 8.7, the URL class is not a global object. I think that you should check if the URL is defined, or you should bump the Node.js version.