### PR TITLE
Trust first proxy when using secure cookies

### DIFF
--- a/01-Login/app.js
+++ b/01-Login/app.js
@@ -60,6 +60,12 @@ var sess = {
 };
 
 if (app.get('env') === 'production') {
+  // Trust first proxy, to prevent "Unable to verify authorization request state."
+  // errors with passport-auth0.
+  // Ref: https://github.com/auth0/passport-auth0/issues/70#issuecomment-480771614
+  // Ref: https://www.npmjs.com/package/express-session#cookiesecure
+  app.set('trust proxy', 1);
+  
   sess.cookie.secure = true; // serve secure cookies, requires https
 }
 


### PR DESCRIPTION
Hi there, thanks for this example app!

As found in https://github.com/auth0/passport-auth0/issues/70#issuecomment-480771614, the secure HTTP cookies may cause the "Unable to verify authorization request state." error with `passport-auth0`.

This PR applies the recommended solution, to trust the first proxy and prevent this issue.

Ref: https://www.npmjs.com/package/express-session#cookiesecure