### PR TITLE
Update Dockerfile to newer node version

### DIFF
--- a/01-Login/Dockerfile
+++ b/01-Login/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.7-alpine
+FROM node:20-alpine
 
 WORKDIR /home/app
 


### PR DESCRIPTION
#153 is failing because of axios using ESM, so move to a newer Node version for the Docker image. We're moving from 8 to 20 so I'm fully expecting another issue to crop up